### PR TITLE
WSC 6.0 compatibility

### DIFF
--- a/acpMenu.xml
+++ b/acpMenu.xml
@@ -23,7 +23,7 @@
 			<controller>wcf\acp\form\ApiSecretAddForm</controller>
 			<parent>wcf.acp.menu.link.wscApi.secrets.list</parent>
 			<permissions>admin.wscApi.canManageSecret</permissions>
-			<icon>fa-plus</icon>
+			<icon>plus</icon>
 		</acpmenuitem>
 	</import>
 </data>

--- a/acptemplates/apiSecretAdd.tpl
+++ b/acptemplates/apiSecretAdd.tpl
@@ -8,7 +8,7 @@
 	
 	<nav class="contentHeaderNavigation">
 		<ul>
-			<li><a href="{link application='wcf' controller='ApiSecretList'}{/link}" class="button"><span class="icon icon16 fa-list"></span> <span>{lang}wcf.acp.menu.link.wscApi.secrets.list{/lang}</span></a></li>
+			<li><a href="{link application='wcf' controller='ApiSecretList'}{/link}" class="button">{icon name='list' size=16} <span>{lang}wcf.acp.menu.link.wscApi.secrets.list{/lang}</span></a></li>
 			
 			{event name='contentHeaderNavigation'}
 		</ul>

--- a/acptemplates/apiSecretAdd.tpl
+++ b/acptemplates/apiSecretAdd.tpl
@@ -107,7 +107,7 @@
     
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		{@SECURITY_TOKEN_INPUT_TAG}
+		{csrfToken}
 	</div>
 </form>
 

--- a/acptemplates/apiSecretDocumentation.tpl
+++ b/acptemplates/apiSecretDocumentation.tpl
@@ -13,7 +13,7 @@
 
 	<nav class="contentHeaderNavigation">
 		<ul>
-			<li><a href="{link application='wcf' controller='ApiSecretList'}{/link}" class="button"><span class="icon icon16 fa-list"></span> <span>{lang}wcf.acp.menu.link.wscApi.secrets.list{/lang}</span></a></li>
+			<li><a href="{link application='wcf' controller='ApiSecretList'}{/link}" class="button">{icon name='list' size=16} <span>{lang}wcf.acp.menu.link.wscApi.secrets.list{/lang}</span></a></li>
 
 			{event name='contentHeaderNavigation'}
 		</ul>

--- a/acptemplates/apiSecretList.tpl
+++ b/acptemplates/apiSecretList.tpl
@@ -1,11 +1,5 @@
 {include file='header' pageTitle='wcf.acp.menu.link.wscApi.secrets.list'}
 
-<script data-relocate="true">
-	$(function() {
-		new WCF.Action.Delete('wcf\\data\\ApiSecretAction', '.jsSecretRow');
-	});
-</script>
-
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
 		<h1 class="contentTitle">{lang}wcf.acp.menu.link.wscApi.secrets.list{/lang}</h1>
@@ -23,7 +17,7 @@
 {hascontent}
 	<div id="boardNodeList" class="section sortableListContainer">
 		<ol id="boardContainer0" class="sortableList" data-object-id="0">
-			<table class="table">
+			<table class="table jsObjectActionContainer" data-object-action-class-name="wcf\data\ApiSecretAction">
 			<thead>
 				<tr>
 					<th></th>
@@ -34,10 +28,10 @@
 			<tbody>
 			{content}
 				{foreach from=$secrets item=secret}
-					<tr class="jsSecretRow">
+					<tr class="jsObjectActionObject" data-object-id="{$secret.secretID}">
 						<td class="columnIcon">
 							<a href="{link controller='ApiSecretEdit' id=$secret.secretID}{/link}" title="{lang}wcf.global.button.edit{/lang}" class="jsTooltip">{icon name='pencil' size=16}</a>
-							<span class="icon icon16 fa-times jsDeleteButton jsTooltip pointer" title="{lang}wcf.global.button.delete{/lang}" data-object-id="{@$secret.secretID}" data-confirm-message-html="{lang}TODO{/lang}"></span>
+							{objectAction action="delete" objectTitle=$secret.secretDescription}
 						</td>
 						<td>{$secret.secretID}</td>
 						<td><a title="{lang}wcf.acp.user.edit{/lang}" href="{link controller='ApiSecretEdit' id=$secret.secretID}{/link}">{$secret.secretDescription}</a></td>

--- a/acptemplates/apiSecretList.tpl
+++ b/acptemplates/apiSecretList.tpl
@@ -13,7 +13,7 @@
 	
 	<nav class="contentHeaderNavigation">
 		<ul>
-			<li><a href="{link application='wcf' controller='ApiSecretAdd'}{/link}" class="button"><span class="icon icon16 fa-plus"></span> <span>{lang}wcf.acp.menu.link.wscApi.secrets.add{/lang}</span></a></li>
+			<li><a href="{link application='wcf' controller='ApiSecretAdd'}{/link}" class="button">{icon name='plus' size=16} <span>{lang}wcf.acp.menu.link.wscApi.secrets.add{/lang}</span></a></li>
 			
 			{event name='contentHeaderNavigation'}
 		</ul>
@@ -36,7 +36,7 @@
 				{foreach from=$secrets item=secret}
 					<tr class="jsSecretRow">
 						<td class="columnIcon">
-							<a href="{link controller='ApiSecretEdit' id=$secret.secretID}{/link}" title="{lang}wcf.global.button.edit{/lang}" class="jsTooltip"><span class="icon icon16 fa-pencil"></span></a>
+							<a href="{link controller='ApiSecretEdit' id=$secret.secretID}{/link}" title="{lang}wcf.global.button.edit{/lang}" class="jsTooltip">{icon name='pencil' size=16}</a>
 							<span class="icon icon16 fa-times jsDeleteButton jsTooltip pointer" title="{lang}wcf.global.button.delete{/lang}" data-object-id="{@$secret.secretID}" data-confirm-message-html="{lang}TODO{/lang}"></span>
 						</td>
 						<td>{$secret.secretID}</td>

--- a/files/lib/acp/form/ApiSecretAddForm.class.php
+++ b/files/lib/acp/form/ApiSecretAddForm.class.php
@@ -77,7 +77,7 @@ class ApiSecretAddForm extends AbstractForm {
 		if (!empty($_POST['secretKey'])) {
 			$this->secretKey = StringUtil::trim($_POST['secretKey']);
 		} else {
-			$this->secretKey = bin2hex(CryptoUtil::randomBytes(16));
+			$this->secretKey = bin2hex(random_bytes(16));
 		}
 
 		if (!empty($_POST['secretDescription'])) {

--- a/files/lib/api/ThreadApi.class.php
+++ b/files/lib/api/ThreadApi.class.php
@@ -14,6 +14,21 @@ use wcf\system\api\ApiResponse;
  * @package	at.megathorx.wsc-api
  */
 class ThreadApi extends BaseApi {
+    protected $attachmentHandler;
+
+    protected $htmlInputProcessor;
+
+    protected $enableTimeObj;
+
+    protected $subscribeThread;
+
+    protected $optionHandler;
+
+    protected $type;
+
+    protected $boardIDs;
+
+    protected $labelIDs;
 
     /**
      * @api

--- a/files/lib/api/ThreadApi.class.php
+++ b/files/lib/api/ThreadApi.class.php
@@ -1,9 +1,12 @@
 <?php
 namespace wcf\api;
 
+use wbb\data\thread\Thread;
+use wbb\data\thread\ThreadAction;
 use wcf\util\StringUtil;
 use wcf\system\exception\ApiException;
 use wbb\data\thread\ThreadList;
+use wbb\system\label\object\ThreadLabelObjectHandler;
 use wcf\system\api\ApiResponse;
 
 /**

--- a/files/lib/system/user/notification/event/WscApiUserNotificationEvent.class.php
+++ b/files/lib/system/user/notification/event/WscApiUserNotificationEvent.class.php
@@ -31,7 +31,7 @@ class WscApiUserNotificationEvent extends AbstractSharedUserNotificationEvent {
 	/**
 	 * @inheritDoc
 	 */
-	public function getTitle() {
+	public function getTitle(): string {
 		return $this->getUserNotificationObject()->title;
 	}
 
@@ -69,7 +69,7 @@ class WscApiUserNotificationEvent extends AbstractSharedUserNotificationEvent {
 	/**
 	 * @inheritDoc
 	 */
-	public function getLink() {
+	public function getLink(): string {
 		return $this->getUserNotificationObject()->url;
 	}
 

--- a/files/lib/system/user/notification/object/ApiNotificationUserNotificationObject.class.php
+++ b/files/lib/system/user/notification/object/ApiNotificationUserNotificationObject.class.php
@@ -13,7 +13,7 @@ class ApiNotificationUserNotificationObject extends DatabaseObjectDecorator impl
 	/**
 	 * @inheritDoc
 	 */
-	public function getTitle() {
+	public function getTitle(): string {
 		return $this->getDecoratedObject()->title;
 	}
 

--- a/package.xml
+++ b/package.xml
@@ -13,12 +13,8 @@
 		<authorurl>https://github.com/eXo-OpenSource/wsc-api</authorurl>
 	</authorinformation>
 	<requiredpackages>
-		<requiredpackage minversion="3.0.0">com.woltlab.wcf</requiredpackage>
+		<requiredpackage minversion="6.0.2">com.woltlab.wcf</requiredpackage>
 	</requiredpackages>
-	<compatibility>
-		<api version="2018"/>
-		<api version="2019"/>
-	</compatibility>
 	<instructions type="install">
 		<instruction type="file"/>
 		<instruction type="language"/>


### PR DESCRIPTION
I have made some changes so that the plugin can run under WSC 6.0. I have only done the minimum at this point. In principle, the code still contains some deprecations and still relies on the outdated SQL-PIP.

You still have to add the update instructions to the `package.xml`. The PIPs `file`, `acpMenu` and `acptemplates` have changed.